### PR TITLE
Fix docs, test and build config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,7 +222,7 @@ gradle-app.setting
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar
 
-# Avoid ignore Gradle wrappper properties
+# Avoid ignore Gradle wrapper properties
 !gradle-wrapper.properties
 
 # Cache of project

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Docker Compose file for MongoDB.
 ## Branch strategy
 
 The project follows the branch workflow defined in `codex.yml`.
-Development is carried out on the `work` branch. Changes are
-merged into `master` when they are ready for release.
+Development is carried out on the `develop` branch. Changes are
+merged into `main` when they are ready for release.
 
 ## Building and testing
 
@@ -21,5 +21,11 @@ Use the Gradle wrapper to build and run tests:
 
 ## Scripts
 
-There is currently no `scripts/` directory in this repository.
-This section can describe script usage once scripts are added.
+The `scripts/` directory provides utilities for release tagging,
+deployment and postmortem notes. It contains the following helper
+scripts:
+
+* `auto-tag.sh`
+* `create-postmortem.sh`
+* `deploy-prod.sh`
+* `release-notes.sh`

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(23)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 

--- a/src/test/java/se/overdo/OverdoApplicationTests.java
+++ b/src/test/java/se/overdo/OverdoApplicationTests.java
@@ -1,13 +1,21 @@
 package se.overdo;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
 
-@SpringBootTest
+@SpringBootTest(properties = "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration")
 class OverdoApplicationTests {
+
+    @Autowired
+    private ApplicationContext context;
 
     @Test
     void contextLoads() {
+        Assertions.assertThat(context).isNotNull();
+        Assertions.assertThat(context.getBean(OverdoApplication.class)).isNotNull();
     }
 
 }


### PR DESCRIPTION
## Summary
- fix a typo in `.gitignore`
- set Java toolchain to JDK 21
- clarify branch workflow and scripts in README
- improve Overdo application test coverage

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_685aa9582570832e8fcf9d50ec05cd22