### PR TITLE
fix: 문서, 스크립트 오타 수정 및 테스트 개선

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Use the Gradle wrapper to build and run tests:
 ./gradlew test    # run tests only
 ```
 
+Requires JDK 21 or higher.
+
 ## Scripts
 
 The `scripts/` directory provides utilities for release tagging,

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Usage: ./deploy-prod.sh
-# Deploy develop branch directly to main and production.
+# Deploy the develop branch directly to main and production.
 
 set -e
 

--- a/src/test/java/se/overdo/GreetingControllerTests.java
+++ b/src/test/java/se/overdo/GreetingControllerTests.java
@@ -2,16 +2,14 @@ package se.overdo;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest(properties = "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration")
-@AutoConfigureMockMvc
+@WebMvcTest(GreetingController.class)
 class GreetingControllerTests {
 
     @Autowired

--- a/src/test/java/se/overdo/OverdoApplicationTests.java
+++ b/src/test/java/se/overdo/OverdoApplicationTests.java
@@ -1,10 +1,11 @@
 package se.overdo;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(properties = "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration")
 class OverdoApplicationTests {
@@ -14,8 +15,9 @@ class OverdoApplicationTests {
 
     @Test
     void contextLoads() {
-        Assertions.assertThat(context).isNotNull();
-        Assertions.assertThat(context.getBean(OverdoApplication.class)).isNotNull();
+        assertThat(context).isNotNull();
+        assertThat(context.getBean(OverdoApplication.class)).isNotNull();
+        assertThat(context.getBean(GreetingController.class)).isNotNull();
     }
 
 }


### PR DESCRIPTION
## Summary
- 배포 스크립트 주석 오타 수정
- README에 Java 21 필요 사항 명시
- 컨트롤러 테스트를 `@WebMvcTest`로 변경
- 애플리케이션 컨텍스트 테스트에서 `GreetingController` 검증 추가

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685b9ef997f4832e8efed91df8c3e638